### PR TITLE
docs(discovery): refine option framing

### DIFF
--- a/.agents/skills/loop-discovery/SKILL.md
+++ b/.agents/skills/loop-discovery/SKILL.md
@@ -26,9 +26,13 @@ Discovery is a collaborative brainstorming phase and stays in conversation until
    - Ask exactly one high-leverage question per turn.
    - Prioritize purpose, constraints, non-goals, success criteria, and tradeoffs.
    - When related docs/contracts are `Draft`, keep probing assumptions until uncertainty is reduced.
-4. Propose 2-3 approaches with trade-offs and a recommendation.
-5. Converge on one approach with explicit acceptance criteria and human approval.
-6. Produce a concise discovery summary in conversation for plan handoff.
+4. When a decision benefits from explicit framing, present 2-4 realistic options.
+   - Choose the count based on the real decision shape: 2 for a true fork, 3-4 when there are meaningful alternatives.
+   - Give each option a very short trade-off note with one clear upside and one clear downside.
+   - Keep options concise and non-redundant; do not pad weak options just to reach four.
+5. Recommend a direction with short rationale when the trade-offs are asymmetric.
+6. Converge on one approach with explicit acceptance criteria and human approval.
+7. Produce a concise discovery summary in conversation for plan handoff.
 
 ## Output
 
@@ -47,3 +51,4 @@ Conversation-only discovery summary with:
 - Do not create a worktree automatically.
 - Do not proceed to `loop-plan` until the discovery summary is approved by the human.
 - Do not ask bundled multi-question prompts; keep one question per turn.
+- Do not turn option framing into long compare tables or verbose essays.

--- a/.agents/skills/loop-discovery/agents/openai.yaml
+++ b/.agents/skills/loop-discovery/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Loop Discovery"
-  short_description: "Socratic discovery before planning"
-  default_prompt: "Use $loop-discovery to run conversation-only discovery (one question at a time), converge on an approved approach, then hand off to planning."
+  short_description: "Socratic discovery with concise tradeoffs"
+  default_prompt: "Use $loop-discovery to run conversation-only discovery one question at a time, offer 2-4 concise options with brief pros/cons when useful, converge on an approved approach, then hand off to planning."

--- a/docs/exec-plans/completed/2026-03-06-discovery-option-framing.md
+++ b/docs/exec-plans/completed/2026-03-06-discovery-option-framing.md
@@ -1,0 +1,81 @@
+# Discovery Option Framing Calibration
+
+## Metadata
+
+- Plan name: Discovery Option Framing Calibration
+- Owner: Human+Codex
+- Date: 2026-03-06
+- Related issue/task: TASK-0005
+- Tracker IDs: TASK-0005
+
+## Objective
+
+Refine `loop-discovery` so Socratic discovery remains concise while offering better decision framing: 2-4 realistic options when useful, each with a short upside/downside note.
+
+## Scope
+
+- In scope:
+  - Update `loop-discovery` skill instructions for context-shaped option counts.
+  - Require brief pros/cons for discovery options without turning responses verbose.
+  - Sync `loop-discovery/agents/openai.yaml` so UI entry text matches the revised behavior.
+  - Capture isolated subagent test evidence for the revised option framing.
+- Out of scope:
+  - Changing discovery from one-question-per-turn behavior.
+  - Changing planning, execution, or merge mechanics outside the discovery skill.
+
+## Acceptance Criteria
+
+- [x] `.agents/skills/loop-discovery/SKILL.md` allows 2-4 realistic options based on decision shape.
+- [x] `.agents/skills/loop-discovery/SKILL.md` requires a very short upside/downside note per option and explicitly guards against verbose compare tables.
+- [x] `.agents/skills/loop-discovery/agents/openai.yaml` reflects the revised concise-tradeoff behavior.
+- [x] Isolated subagent tests show both a 3-option case and a true 2-option fork without padding weak alternatives.
+
+## Work Breakdown
+
+1. Inspect the current skill contract and metadata to identify why discovery responses were converging on sparse option framing.
+2. Update the skill contract and UI metadata to prefer 2-4 realistic options with brief tradeoffs.
+3. Validate the skill with structural checks and isolated subagent simulations.
+4. Run repository review/final-gate workflow and record evidence.
+
+## Validation Plan
+
+- `python3 /Users/yaozhang/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/loop-discovery`
+- Isolated subagent simulations for:
+  - a 3-option architectural fork
+  - a 3-option implementation-slice choice
+  - a true 2-option scope fork
+- `find docs/exec-plans/completed -maxdepth 1 -name '*.md' ! -name 'README.md' -exec basename {} \; | while read -r file; do rg -q "$file" docs/exec-plans/completed/README.md || echo "missing:$file"; done`
+- `loop-review-loop` in `full-pr` mode
+- `loop-final-gate` against the latest review artifact and local CI-equivalent metadata
+
+## Validation Summary
+
+- Executed `python3 /Users/yaozhang/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/loop-discovery`; the skill passed validation.
+- Executed three isolated subagent simulations with `fork_context=false` and archived the observed response shapes here:
+  - Prompt: design the first `Segment` entity for evidence anchoring. Observed result: 3 options, each with one short upside and one short downside, followed by a concise recommendation.
+  - Prompt: choose the first implementation slice after evidence anchoring. Observed result: 3 options, each with one short upside and one short downside, with no long compare table.
+  - Prompt: decide whether v1 `Segment` must support podcast/audio locators now. Observed result: 2 options only, each with one short upside and one short downside, confirming true binary forks do not get padded with weak extras.
+- Executed `find docs/exec-plans/completed -maxdepth 1 -name '*.md' ! -name 'README.md' -exec basename {} \; | while read -r file; do rg -q "$file" docs/exec-plans/completed/README.md || echo "missing:$file"; done`; the command produced no missing entries, so the completed-plan catalog stayed in sync.
+- Executed `loop-review-loop` full-PR round `20260306-015645`; review gate passed with `BLOCKER=0`, `IMPORTANT=0`.
+- Executed `loop-review-loop` delta round `20260306-020428`; review gate blocked with `BLOCKER=0`, `IMPORTANT=1`, which drove the archive-evidence updates in this plan and the catalog-sync rule added to `docs/exec-plans/completed/README.md`.
+- Executed `loop-review-loop` delta round `20260306-020831`; review gate passed with `BLOCKER=0`, `IMPORTANT=0` after the archive-evidence updates.
+- Executed `loop-final-gate` against `.local/loop/review-20260306-020831.json` and `.local/loop/ci-20260306-discovery-option-framing.json`; the gate passed with `review_ok=true`, `ci_ok=true`, `branch_ok=true`, and `docs_ok=true`.
+
+## Risks and Mitigations
+
+- Risk: The model still defaults to 3 options even for clear binary decisions.
+  - Mitigation: Add explicit wording that 2 options are preferred for a true fork and verify with an isolated 2-option test.
+- Risk: Adding pros/cons makes discovery verbose.
+  - Mitigation: Require one very short upside and one very short downside per option, and forbid long compare tables or essays.
+
+## Completion Summary
+
+- Delivered:
+  - Reframed discovery option guidance from `2-3 approaches` to `2-4 realistic options` based on decision shape.
+  - Required concise upside/downside notes per option.
+  - Synced the discovery skill UI prompt with the new framing rules.
+  - Captured isolated subagent evidence showing both 3-option and 2-option behavior.
+- Not delivered:
+  - No changes to the surrounding discovery/plan workflow beyond option framing.
+- Tracker updates:
+  - Marked `TASK-0005` as `done` and linked it to this archived plan.

--- a/docs/exec-plans/completed/README.md
+++ b/docs/exec-plans/completed/README.md
@@ -13,3 +13,20 @@ Each completed plan should include:
 - validation summary
 - open follow-up/debt IDs (if any)
 - mapping to tracker IDs in `../tracker.md`
+- when the catalog changes, a validation check that every completed plan file in this folder is listed below
+
+Recommended catalog sync check:
+
+```sh
+find docs/exec-plans/completed -maxdepth 1 -name '*.md' ! -name 'README.md' -exec basename {} \; \
+  | while read -r file; do
+      rg -q "$file" docs/exec-plans/completed/README.md || echo "missing:$file"
+    done
+```
+
+## Catalog
+
+| Plan | Date | Summary |
+| --- | --- | --- |
+| [`2026-03-05-skill-flow-calibration.md`](./2026-03-05-skill-flow-calibration.md) | 2026-03-05 | Calibrated task intake, discovery behavior, and plan handoff rules. |
+| [`2026-03-06-discovery-option-framing.md`](./2026-03-06-discovery-option-framing.md) | 2026-03-06 | Refined discovery option framing to support concise 2-4 options with brief tradeoffs. |

--- a/docs/exec-plans/tracker.md
+++ b/docs/exec-plans/tracker.md
@@ -51,5 +51,6 @@ Single tactical tracker for priorities, follow-ups, and debt.
 
 | ID | Title | Priority | Status | Owner | Links | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
+| TASK-0005 | Refine discovery option framing ergonomics | P2 | done | Human+Codex | `.agents/skills/loop-discovery/SKILL.md`, `.agents/skills/loop-discovery/agents/openai.yaml`, `docs/exec-plans/completed/2026-03-06-discovery-option-framing.md` | Completed: discovery now uses context-shaped 2-4 options with concise tradeoff notes, validated with isolated subagent tests. |
 | TASK-0004 | Calibrate task-intake and discovery flow in AGENTS/skills | P0 | done | Human+Codex | `AGENTS.md`, `.agents/skills/AGENT_LOOP_WORKFLOW.md`, `.agents/skills/loop-discovery/SKILL.md`, `.agents/skills/loop-plan/SKILL.md`, `docs/exec-plans/completed/2026-03-05-skill-flow-calibration.md` | Completed: task confirmation gate + conversation-only Socratic discovery are now codified. |
 | FUP-0003 | Harden review-loop and final-gate artifact contracts | P1 | done | Codex | `.agents/skills/loop-review-loop/scripts/`, `.agents/skills/loop-final-gate/scripts/final_gate.sh`, commit `cbd4636` | Added fail-closed validation, safe cleanup behavior, and regression harness. |


### PR DESCRIPTION
## Summary
- refine `loop-discovery` so option framing uses 2-4 realistic choices based on decision shape
- require one concise upside/downside note per option and keep discovery from expanding into long compare tables
- archive the calibration in `docs/exec-plans`, add tracker evidence, and add a completed-plan catalog sync check

## Validation
- `python3 /Users/yaozhang/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/loop-discovery`
- isolated subagent checks covered both 3-option and true 2-option discovery forks
- `find docs/exec-plans/completed -maxdepth 1 -name '*.md' ! -name 'README.md' -exec basename {} \; | while read -r file; do rg -q "$file" docs/exec-plans/completed/README.md || echo "missing:$file"; done`
- `git diff --check`
- `loop-review-loop` full-pr round `20260306-015645` and delta round `20260306-020831` passed after fixing blocked delta round `20260306-020428`
- `loop-final-gate` passed against `.local/loop/review-20260306-020831.json` and `.local/loop/ci-20260306-discovery-option-framing.json`

## Notes
- completed execution record: `docs/exec-plans/completed/2026-03-06-discovery-option-framing.md`
